### PR TITLE
Add support for RSA_SIGN_PKCS1_4096_SHA256 - fixes #16

### DIFF
--- a/kmscng/algorithm_details.cc
+++ b/kmscng/algorithm_details.cc
@@ -25,6 +25,7 @@ namespace cloud_kms::kmscng {
 absl::flat_hash_set<std::wstring> algorithm_identifiers = {
     {BCRYPT_ECDSA_P256_ALGORITHM},
     {BCRYPT_ECDSA_P384_ALGORITHM},
+    {BCRYPT_RSA_ALGORITHM},
 };
 
 struct AlgorithmCmp {
@@ -57,6 +58,13 @@ static const auto* const kAlgorithmDetails =
             kms_v1::CryptoKey::ASYMMETRIC_SIGN,             // purpose
             NCRYPT_ECDSA_ALGORITHM_GROUP,                   // algorithm_group
             BCRYPT_ECDSA_P384_ALGORITHM,  // algorithm_property
+            NCRYPT_ALLOW_SIGNING_FLAG,    // key_usage
+        },
+        {
+            kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA256,  // algorithm
+            kms_v1::CryptoKey::ASYMMETRIC_SIGN,             // purpose
+            NCRYPT_RSA_ALGORITHM_GROUP,                     // algorithm_group
+            BCRYPT_RSA_ALGORITHM,         // algorithm_property
             NCRYPT_ALLOW_SIGNING_FLAG,    // key_usage
         },
     };

--- a/kmscng/algorithm_details_test.cc
+++ b/kmscng/algorithm_details_test.cc
@@ -34,6 +34,18 @@ TEST(GetAlgorithmDetailsTest, AlgorithmEc) {
   EXPECT_EQ(details.key_usage, NCRYPT_ALLOW_SIGNING_FLAG);
 }
 
+TEST(GetAlgorithmDetailsTest, AlgorithmRsa) {
+  ASSERT_OK_AND_ASSIGN(
+      AlgorithmDetails details,
+      GetDetails(kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA256));
+
+  EXPECT_EQ(details.algorithm, kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA256);
+  EXPECT_EQ(details.purpose, kms_v1::CryptoKey::ASYMMETRIC_SIGN);
+  EXPECT_THAT(details.algorithm_group, NCRYPT_RSA_ALGORITHM_GROUP);
+  EXPECT_EQ(details.algorithm_property, BCRYPT_RSA_ALGORITHM);
+  EXPECT_EQ(details.key_usage, NCRYPT_ALLOW_SIGNING_FLAG);
+}
+
 TEST(GetAlgorithmDetailsTest, AlgorithmNotFound) {
   absl::StatusOr<AlgorithmDetails> details =
       GetDetails(kms_v1::CryptoKeyVersion::EXTERNAL_SYMMETRIC_ENCRYPTION);

--- a/kmscng/docs/user_guide.md
+++ b/kmscng/docs/user_guide.md
@@ -8,6 +8,7 @@
 4.  [Functions](#functions)
 5.  [Cryptographic operations](#cryptographic-operations)
     1.  [ECDSA signing](#ecdsa-signing)
+    2.  [RSA signing](#rsa-signing)
 6.  [Limitations](#limitations)
 7.  [FAQs](#faqs)
 
@@ -146,6 +147,18 @@ CNG Function                 | [`NCryptSignHash`][NCryptSignHash]
 CNG Algorithm ID             | `BCRYPT_ECDSA_P256_ALGORITHM`, `BCRYPT_ECDSA_P384_ALGORITHM`
 Cloud KMS Algorithm          | [`EC_SIGN_P256_SHA256`][kms-ec-algorithms], [`EC_SIGN_P384_SHA384`][kms-ec-algorithms]
 
+### RSA Signing
+
+The provider may be used for RSA signing. The expected input for a signing
+operation is a message digest of the appropriate length for the Cloud KMS
+algorithm.
+
+Compatibility                | Compatible With
+---------------------------- | ---------------
+CNG Function                 | [`NCryptSignHash`][NCryptSignHash]
+CNG Algorithm ID             | `BCRYPT_RSA_ALGORITHM`
+Cloud KMS Algorithm          | [`RSA_SIGN_PKCS1_4096_SHA256`][kms-rsa-algorithms]
+
 ## Limitations
 
 ### Key purpose and protection level
@@ -155,8 +168,8 @@ these characteristics:
 
 *   The purpose for the CryptoKey is `ASYMMETRIC_SIGN`.
 *   The protection level for the CryptoKeyVersion is `HSM`.
-*   The algorithm for the CryptoKeyVersion is `EC_SIGN_P256_SHA256`, or
-    `EC_SIGN_P384_SHA384`.
+*   The algorithm for the CryptoKeyVersion is `EC_SIGN_P256_SHA256`,
+    `EC_SIGN_P384_SHA384` or `RSA_SIGN_PKCS1_4096_SHA256`.
 
 The CNG provider returns an error when trying to load keys that don't conform to
 these requirements.
@@ -203,6 +216,7 @@ and sets the environment variable to point to that location.
 [gcp-authn-prod]: https://cloud.google.com/docs/authentication/production
 [gcp-service-terms]: https://cloud.google.com/terms/service-terms#1
 [kms-ec-algorithms]: https://cloud.google.com/kms/docs/algorithms#elliptic_curve_signing_algorithms
+[kms-rsa-algorithms]: https://cloud.google.com/kms/docs/algorithms#rsa_signing_algorithms
 [kms-permissions-and-roles]: https://cloud.google.com/kms/docs/reference/permissions-and-roles
 [kms-rsa-sign-algorithms]: https://cloud.google.com/kms/docs/algorithms#rsa_signing_algorithms
 [msvc-redistributable]: https://aka.ms/vs/17/release/vc_redist.x64.exe

--- a/kmscng/object.h
+++ b/kmscng/object.h
@@ -37,6 +37,9 @@ class Object {
   EC_KEY* ec_public_key() const {
     return EVP_PKEY_get0_EC_KEY(public_key_.get());
   }
+  RSA* rsa_public_key() const {
+    return EVP_PKEY_get0_RSA(public_key_.get());
+  }
 
  private:
   Object(std::string kms_key_name, std::unique_ptr<KmsClient> client,

--- a/kmscng/provider.h
+++ b/kmscng/provider.h
@@ -22,12 +22,16 @@
 
 namespace cloud_kms::kmscng {
 
-static constexpr std::array<NCryptAlgorithmName, 2> kAlgorithmNames{
+static constexpr std::array<NCryptAlgorithmName, 3> kAlgorithmNames{
     {{.pszName = const_cast<wchar_t*>(BCRYPT_ECDSA_P256_ALGORITHM),
       .dwClass = NCRYPT_SIGNATURE_INTERFACE,
       .dwAlgOperations = NCRYPT_SIGNATURE_OPERATION,
       .dwFlags = 0},
      {.pszName = const_cast<wchar_t*>(BCRYPT_ECDSA_P384_ALGORITHM),
+      .dwClass = NCRYPT_SIGNATURE_INTERFACE,
+      .dwAlgOperations = NCRYPT_SIGNATURE_OPERATION,
+      .dwFlags = 0},
+      {.pszName = const_cast<wchar_t*>(BCRYPT_RSA_ALGORITHM),
       .dwClass = NCRYPT_SIGNATURE_INTERFACE,
       .dwAlgOperations = NCRYPT_SIGNATURE_OPERATION,
       .dwFlags = 0}}};


### PR DESCRIPTION
Bringing support for RSA_SIGN_PKCS1_4096_SHA256 crypto algorithm.

Successfully signed a Windows artifact using the locally built provider, digital signature validates OK.

Note: documentation is currently not updated with this PR.

Please feel free to ask / amend / request changes. :-)