### PR TITLE
Add support for RSA_SIGN_PKCS1_4096_SHA512

### DIFF
--- a/kmscng/algorithm_details.cc
+++ b/kmscng/algorithm_details.cc
@@ -81,6 +81,13 @@ static const auto* const kAlgorithmDetails =
             BCRYPT_RSA_ALGORITHM,        // algorithm_property
             NCRYPT_ALLOW_SIGNING_FLAG,   // key_usage
         },
+        {
+            kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA512,  // algorithm
+            kms_v1::CryptoKey::ASYMMETRIC_SIGN,                    // purpose
+            NCRYPT_RSA_ALGORITHM_GROUP,  // algorithm_group
+            BCRYPT_RSA_ALGORITHM,        // algorithm_property
+            NCRYPT_ALLOW_SIGNING_FLAG,   // key_usage
+        },
     };
 
 absl::StatusOr<AlgorithmDetails> GetDetails(

--- a/kmscng/docs/user_guide.md
+++ b/kmscng/docs/user_guide.md
@@ -157,7 +157,7 @@ Compatibility                | Compatible With
 ---------------------------- | ---------------
 CNG Function                 | [`NCryptSignHash`][NCryptSignHash]
 CNG Algorithm ID             | `BCRYPT_RSA_ALGORITHM`
-Cloud KMS Algorithm          | [`RSA_SIGN_PKCS1_2048_SHA256`][kms-rsa-algorithms], [`RSA_SIGN_PKCS1_3072_SHA256`][kms-rsa-algorithms], [`RSA_SIGN_PKCS1_4096_SHA256`][kms-rsa-algorithms]
+Cloud KMS Algorithm          | [`RSA_SIGN_PKCS1_2048_SHA256`][kms-rsa-algorithms], [`RSA_SIGN_PKCS1_3072_SHA256`][kms-rsa-algorithms], [`RSA_SIGN_PKCS1_4096_SHA256`][kms-rsa-algorithms], [`RSA_SIGN_PKCS1_4096_SHA512`][kms-rsa-algorithms]
 
 ## Limitations
 
@@ -170,7 +170,7 @@ these characteristics:
 *   The protection level for the CryptoKeyVersion is `HSM`.
 *   The algorithm for the CryptoKeyVersion is `EC_SIGN_P256_SHA256`,
     `EC_SIGN_P384_SHA384`, `RSA_SIGN_PKCS1_2048_SHA256`,
-    `RSA_SIGN_PKCS1_3072_SHA256` or `RSA_SIGN_PKCS1_4096_SHA256`.
+    `RSA_SIGN_PKCS1_3072_SHA256`, `RSA_SIGN_PKCS1_4096_SHA256` or `RSA_SIGN_PKCS1_4096_SHA512`.
 
 The CNG provider returns an error when trying to load keys that don't conform to
 these requirements.

--- a/kmscng/operation/sign_utils.cc
+++ b/kmscng/operation/sign_utils.cc
@@ -78,6 +78,7 @@ absl::Status CopySignature(Object* object, std::string_view src,
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_2048_SHA256:
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_3072_SHA256:
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA256:
+    case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA512:
       return CopyRsaSignature(object, src, dest);
     default:
       return NewInternalError(
@@ -173,6 +174,7 @@ absl::Status IsValidSigningAlgorithm(
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_2048_SHA256:
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_3072_SHA256:
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA256:
+    case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA512:
       return absl::OkStatus();
     default:
       return NewInternalError(
@@ -192,6 +194,8 @@ absl::StatusOr<const EVP_MD*> DigestForAlgorithm(
       return EVP_sha256();
     case kms_v1::CryptoKeyVersion::EC_SIGN_P384_SHA384:
       return EVP_sha384();
+    case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA512:
+      return EVP_sha512();
     default:
       return NewInternalError(
           absl::StrFormat("cannot get digest type for algorithm: %d",
@@ -224,6 +228,7 @@ absl::StatusOr<uint32_t> MagicIdForAlgorithm(
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_2048_SHA256:
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_3072_SHA256:
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA256:
+    case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA512:
       return BCRYPT_RSAPUBLIC_MAGIC;
     default:
       return NewInternalError(
@@ -273,6 +278,7 @@ absl::StatusOr<std::vector<uint8_t>> SerializePublicKey(Object* object) {
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_2048_SHA256:
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_3072_SHA256:
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA256:
+    case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA512:
       return SerializePublicRsaKey(object);
     default:
       return NewInternalError(
@@ -296,6 +302,7 @@ absl::StatusOr<size_t> SignatureLength(Object* object) {
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_3072_SHA256:
       return 3072 / 8;
     case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA256:
+    case kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA512:
       return 4096 / 8;
     default:
       return NewInternalError(
@@ -335,6 +342,9 @@ absl::Status SignDigest(Object* object, absl::Span<const uint8_t> digest,
       break;
     case NID_sha384:
       req.mutable_digest()->set_sha384(digest.data(), digest.size());
+      break;
+    case NID_sha512:
+      req.mutable_digest()->set_sha512(digest.data(), digest.size());
       break;
     default:
       return NewInternalError(

--- a/kmscng/operation/sign_utils_test.cc
+++ b/kmscng/operation/sign_utils_test.cc
@@ -39,7 +39,8 @@ const std::array kSupportedAlgorithms = {
     kms_v1::CryptoKeyVersion::EC_SIGN_P384_SHA384,
     kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_2048_SHA256,
     kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_3072_SHA256,
-    kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA256
+    kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA256,
+    kms_v1::CryptoKeyVersion::RSA_SIGN_PKCS1_4096_SHA512
 };
 
 INSTANTIATE_TEST_SUITE_P(TestValidAlgorithms, ValidAlgorithmSignUtilsTest,

--- a/kmscng/test/signtool_test.go
+++ b/kmscng/test/signtool_test.go
@@ -87,9 +87,10 @@ func TestSigntoolSuccess(t *testing.T) {
 	}{
 		{"ECDSA256", kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256, x509.ECDSAWithSHA256, "sha256"},
 		{"ECDSA384", kmspb.CryptoKeyVersion_EC_SIGN_P384_SHA384, x509.ECDSAWithSHA384, "sha384"},
-		{"RSA2048", kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256, x509.SHA256WithRSA, "sha256"},
-		{"RSA3072", kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_3072_SHA256, x509.SHA256WithRSA, "sha256"},
-		{"RSA4096", kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA256, x509.SHA256WithRSA, "sha256"},
+		{"RSA2048SHA256", kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256, x509.SHA256WithRSA, "sha256"},
+		{"RSA3072SHA256", kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_3072_SHA256, x509.SHA256WithRSA, "sha256"},
+		{"RSA4096SHA256", kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA256, x509.SHA256WithRSA, "sha256"},
+		{"RSA4096SHA512", kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA512, x509.SHA512WithRSA, "sha512"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Adding support for RSA_SIGN_PKCS1_4096_SHA512 algorithm

Tested signing Windows executable with Google KMS key using algorithm "4096 bit RSA key PKCS#1 v1.5 padding - SHA512 Digest" and the signature was successfully applied.