### PR TITLE
Windows build improvements

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,7 +26,15 @@ select_crypto_library()
 
 load("//kmscng:cpdk.bzl", "cpdk")
 
-cpdk(name = "cpdk")
+cpdk(
+    name = "cpdk_x86",
+    lib_suffix = "x86"
+)
+
+cpdk(
+    name = "cpdk_x64",
+    lib_suffix = "x64"
+)
 
 http_archive(
     name = "wix",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,7 +62,6 @@ http_archive(
 http_archive(
     name = "com_github_grpc_grpc",  # v1.59.1 / 2023-10-06
     patch_args = [
-        "-E",
         "-p1",
     ],
     patches = [
@@ -140,7 +139,6 @@ http_file(
 http_archive(
     name = "rules_foreign_cc",  # 2021-03-18
     patch_args = [
-        "-E",
         "-p1",
     ],
     patches = ["//:third_party/rules_foreign_cc.patch"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,6 +47,12 @@ cloudkms_grpc_service_config(name = "cloudkms_grpc_service_config")
 
 http_archive(
     name = "com_github_gflags_gflags",  # 2020-03-18
+    patch_args = [
+        "-p1",
+    ],
+    patches = [
+        "//:third_party/gflags_windows.patch",
+    ],
     sha256 = "68e26a487038a842da3ef2ddd1f886dad656e9efaf1a3d49e87d1d3a9fa3a8eb",
     strip_prefix = "gflags-addd749114fab4f24b7ea1e0f2f837584389e52c",
     url = "https://github.com/gflags/gflags/archive/addd749114fab4f24b7ea1e0f2f837584389e52c.tar.gz",
@@ -67,6 +73,8 @@ http_archive(
     patches = [
         "//:third_party/grpc_windows_system_roots.patch",
         "//:third_party/grpc_mac_event_engine.patch",
+        "//:third_party/grpc_windows_event_engine.patch",
+        "//:third_party/grpc_cares_build.patch",
     ],
     sha256 = "916f88a34f06b56432611aaa8c55befee96d0a7b7d7457733b9deeacbc016f99",
     strip_prefix = "grpc-1.59.1",

--- a/kmscng/BUILD.bazel
+++ b/kmscng/BUILD.bazel
@@ -31,15 +31,30 @@ cc_test(
     ],
 )
 
+config_setting(
+    name = "windows_x86_64",
+    values = {
+        "cpu": "x64_x86_windows",
+    }
+)
+
 cc_library(
     name = "cng_headers",
     hdrs = ["cng_headers.h"],
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
-        "//kmsp11/util:crypto_utils",
-        "@cpdk//:bcrypt_provider",
-        "@cpdk//:ncrypt_provider",
-    ],
+            "//kmsp11/util:crypto_utils"
+        ] + 
+        select({
+            ":windows_x86_64": [        
+                  "@cpdk_x86//:bcrypt_provider",
+                  "@cpdk_x86//:ncrypt_provider",
+            ], 
+            "//conditions:default": [        
+                  "@cpdk_x64//:bcrypt_provider",
+                  "@cpdk_x64//:ncrypt_provider",
+            ],  
+        }),
 )
 
 cc_library(

--- a/kmscng/cpdk.bzl
+++ b/kmscng/cpdk.bzl
@@ -25,7 +25,7 @@ def _cpdk_impl(repo_ctx):
         fail("Could not find Cryptographic Provider Development Kit at %s", location)
     repo_ctx.symlink(location + "\\Include\\bcrypt_provider.h", "bcrypt_provider.h")
     repo_ctx.symlink(location + "\\Include\\ncrypt_provider.h", "ncrypt_provider.h")
-    repo_ctx.symlink(location + "\\Lib\\x64", "lib")
+    repo_ctx.symlink(location + "\\Lib\\" + repo_ctx.attr.lib_suffix, "lib")
     repo_ctx.file(
         "BUILD.bazel",
         content = _CPDK_BUILD_FILE_CONTENT,
@@ -34,4 +34,5 @@ def _cpdk_impl(repo_ctx):
 cpdk = repository_rule(
     implementation = _cpdk_impl,
     environ = ["CPDK_LOCATION"],
+    attrs = { "lib_suffix": attr.string(mandatory = True) }
 )

--- a/kmscng/main/BUILD.bazel
+++ b/kmscng/main/BUILD.bazel
@@ -101,7 +101,7 @@ genrule(
         ":kmscng.dll",
     ],
     outs = ["libkmscng.dll"],
-    cmd_bat = "copy $(@D)\\kmscng.dll $(@D)\\libkmscng.dll > NUL && robocopy $(@D) C:\\Windows\\System32 kmscng.dll /xc /xo > NUL & exit /b 0",
+    cmd_bat = "copy $(@D)\\kmscng.dll $(@D)\\libkmscng.dll > NUL && robocopy $(@D) C:\\Windows\\System32 kmscng.dll /xc /xo /r:0 > NUL & exit /b 0",
     target_compatible_with = ["@platforms//os:windows"],
 )
 

--- a/kmsp11/tools/p11fn/function_def_template.bzl
+++ b/kmsp11/tools/p11fn/function_def_template.bzl
@@ -21,6 +21,7 @@ def function_def_template(name, src, out):
         \"$(location //kmsp11/tools/p11fn/templater)\" \
             --func_list_path \"$(location //kmsp11/tools/p11fn:function_defs.textproto)\" \
             --template_path \"$(SRCS)\" > \"$(@)\"""",
+        cmd_bat = "$(location //kmsp11/tools/p11fn/templater) --func_list_path \"$(location //kmsp11/tools/p11fn:function_defs.textproto)\" --template_path \"$(SRCS)\" > \"$(@)\"",
         tools = [
             "//kmsp11/tools/p11fn/templater",
             "//kmsp11/tools/p11fn:function_defs.textproto",

--- a/third_party/gflags_windows.patch
+++ b/third_party/gflags_windows.patch
@@ -1,0 +1,29 @@
+--- a/bazel/gflags.bzl	Wed Mar 18 13:31:18 2020
++++ b/bazel/gflags.bzl	Fri Sep 26 14:06:38 2025
+@@ -49,7 +49,7 @@
+         "src/mutex.h",
+         "src/util.h",
+     ] + select({
+-        "//:x64_windows": [
++        "@platforms//os:windows": [
+             "src/windows_port.cc",
+             "src/windows_port.h",
+         ],
+@@ -74,7 +74,7 @@
+         "-DHAVE_STRTOQ",
+         "-DHAVE_RWLOCK",
+     ] + select({
+-        "//:x64_windows": [
++        "@platforms//os:windows": [
+             "-DOS_WINDOWS",
+         ],
+         "//conditions:default": [
+@@ -86,7 +86,7 @@
+     linkopts = []
+     if threads:
+         linkopts += select({
+-            "//:x64_windows": [],
++            "@platforms//os:windows": [],
+             "//conditions:default": ["-lpthread"],
+         })
+     else:

--- a/third_party/grpc_cares_build.patch
+++ b/third_party/grpc_cares_build.patch
@@ -1,0 +1,17 @@
+--- a/third_party/cares/cares.BUILD	Sat Oct  7 01:44:58 2023
++++ b/third_party/cares/cares.BUILD	Wed Oct 22 11:02:05 2025
+@@ -23,5 +22,0 @@
+-config_setting(
+-    name = "windows",
+-    values = {"cpu": "x64_windows"},
+-)
+-
+@@ -125 +120 @@
+-        ":windows": "@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h",
++        "@platforms//os:windows": "@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h",
+@@ -231 +226 @@
+-        ":windows": [
++        "@platforms//os:windows": [
+@@ -242 +237 @@
+-        ":windows": ["-defaultlib:ws2_32.lib"],
++        "@platforms//os:windows": ["-defaultlib:ws2_32.lib"],

--- a/third_party/grpc_windows_event_engine.patch
+++ b/third_party/grpc_windows_event_engine.patch
@@ -1,0 +1,10 @@
+--- a/src/core/BUILD	Wed Oct 22 09:32:38 2025
++++ b/src/core/BUILD	Fri Sep 26 14:25:53 2025
+@@ -2305,6 +2305,7 @@
+         "//:windows": ["windows_event_engine"],
+         "//:windows_msvc": ["windows_event_engine"],
+         "//:windows_other": ["windows_event_engine"],
++        "@platforms//os:windows": ["windows_event_engine"],
+         "//:mac": [
+             "posix_event_engine",
+             "cf_event_engine",


### PR DESCRIPTION
In the context of issue #56, I am suggesting the following changes that allowed me to compile the entire project both in 64 and 32 bits mode, the latter being done by simply adding `--cpu x64_x86_windows` to the `build` or `test` command line.

While it compiles fine, the tests are failing. 
For kmsp11, I get those kind of error messages:

```
[ RUN      ] GlobalProviderTest.GetProviderAfterSetReturnsProvider
WARNING: Logging before InitGoogleLogging() is written to STDERR
W20251105 15:38:52.389787 33968 credentials_generic.cc:35] Could not get APPDATA environment variable.
W20251105 15:38:52.437902 33968 google_default_credentials.cc:412] Could not create google default credentials: UNKNOWN:creds_path unset {file:"external/com_github_grpc_grpc/src/core/lib/security/credentials/google_default/google_default_credentials.cc", file_line:268, created_time:"2025-11-05T15:38:52.3899925+00:00"}
kmsp11/util/global_provider_test.cc(35): error: Value of: ::cloud_kms::ToStatus(_status_or0.status())
Expected: status is OK
  Actual: INVALID_ARGUMENT: at provider.cc:65: Invalid Application Default Credentials. See https://cloud.google.com/docs/authentication/external/about-adc [type.googleapis.com/kmsp11.StatusDetails='CK_RV=0x7'] (of type absl::Status)
```
But I'm not sure what I can do about that.

For kmscng, I get this error:
```
[ RUN      ] ProvHandleToBytesTest.Success
kmscng/util/string_utils_test.cc(31): error: Expected equality of these values:
  ProvHandleToBytes(handle)
    Which is: "\x1\0\0\0"
  std::string("\x1\0\0\0\0\0\0\0", 8)
    Which is: "\x1\0\0\0\0\0\0\0"
Stack trace:
  005F2E13: cloud_kms::kmscng::`anonymous namespace'::ProvHandleToBytesTest_Success_Test::TestBody
  00633DA0: testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test,void>
  0063381E: testing::internal::HandleExceptionsInMethodIfSupported<testing::Test,void>
  006194D3: testing::Test::Run
  00619DB8: testing::TestInfo::Run
```

This one, I totally understand because a pointer is only 4 bytes in x86 mode, but I'm not sure how to modify the test code so that it works in both 32 and 64 bits.

Please let me know what you think about all this, I hope the commits messages are clear enough